### PR TITLE
モデル・テーブルの作成

### DIFF
--- a/app/models/bean.rb
+++ b/app/models/bean.rb
@@ -1,0 +1,2 @@
+class Bean < ApplicationRecord
+end

--- a/app/models/beans_comment.rb
+++ b/app/models/beans_comment.rb
@@ -1,0 +1,2 @@
+class BeansComment < ApplicationRecord
+end

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -1,0 +1,2 @@
+class Shop < ApplicationRecord
+end

--- a/app/models/shop_comment.rb
+++ b/app/models/shop_comment.rb
@@ -1,0 +1,2 @@
+class ShopComment < ApplicationRecord
+end

--- a/db/migrate/20210902000839_create_shops.rb
+++ b/db/migrate/20210902000839_create_shops.rb
@@ -1,0 +1,14 @@
+class CreateShops < ActiveRecord::Migration[6.1]
+  def change
+    create_table :shops do |t|
+      t.string :name, null: false
+      t.integer :prefacture, null: false
+      t.string :address, null: false
+      t.string :TEL
+      t.text :URL
+      t.string :img
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210902001321_create_beans.rb
+++ b/db/migrate/20210902001321_create_beans.rb
@@ -1,0 +1,15 @@
+class CreateBeans < ActiveRecord::Migration[6.1]
+  def change
+    create_table :beans do |t|
+      t.string :name, null: false
+      t.integer :price, null: false
+      t.integer :country, null: false
+      t.string :farm
+      t.string :variety
+      t.integer :screen_size
+      t.string :img
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210902001538_create_shop_comments.rb
+++ b/db/migrate/20210902001538_create_shop_comments.rb
@@ -1,0 +1,10 @@
+class CreateShopComments < ActiveRecord::Migration[6.1]
+  def change
+    create_table :shop_comments do |t|
+      t.text :content, null: false
+      t.float :rate, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210902001638_create_beans_comments.rb
+++ b/db/migrate/20210902001638_create_beans_comments.rb
@@ -1,0 +1,12 @@
+class CreateBeansComments < ActiveRecord::Migration[6.1]
+  def change
+    create_table :beans_comments do |t|
+      t.text :content, null: false
+      t.float :bitterness, null: false
+      t.float :acidity, null: false
+      t.float :body, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,57 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2021_09_02_001638) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "beans", force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "price", null: false
+    t.integer "country", null: false
+    t.string "farm"
+    t.string "variety"
+    t.integer "screen_size"
+    t.string "img"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "beans_comments", force: :cascade do |t|
+    t.text "content", null: false
+    t.float "bitterness", null: false
+    t.float "acidity", null: false
+    t.float "body", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "shop_comments", force: :cascade do |t|
+    t.text "content", null: false
+    t.float "rate", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "shops", force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "prefacture", null: false
+    t.string "address", null: false
+    t.string "TEL"
+    t.text "URL"
+    t.string "img"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+end


### PR DESCRIPTION
colse #5 

## 実装内容

- Shopモデルとshopsテーブルの作成
  - カラムは`name`(`string`型),`prefacture`(`integer`型),`address`(`string`型),`TEL`(`string`型),`URL`(`text`型),`img`(`string`型)
  - `name`, `prefacture`,`address`のカラムに`NN制約`を適用

- Beanモデルとbeansテーブルの作成
  - カラムは`name`(`string`型),`price`(`integer`型),`country`(`integer`型),`farm`(`string`型),`variety`(`string`型),`screen_size`(`integer`型),`img`(`string`型)
  - `name`,`price`,`country`カラムに`NN制約`を適用

- Shop_Commentモデルとshop_commentsテーブルの作成
  - カラムは`content`(`text`型),`rate`(`float`型)
  - 全てのカラムに`NN制約`を適用

- Beans_Commentモデルとbeans_commentsテーブルの作成
  - カラムは`content`(`text`型),`bitterness`(`float`型),`acidity`(`float`型),`body`(`float`型)
  - 全てのカラムに`NN制約`を適用

- `rails db migrate`を実行

## 動作確認

- [x] ターミナルから以下を実行し、`NN制約`が入っていることを確認

```
rails db

\d shops
\d beans
\d shop_comments
\d beans_comments
```