### PR TITLE
詳細ページのデフォルト画像の表示の不具合を解消

### DIFF
--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -17,6 +17,7 @@ class ShopsController < ApplicationController
 
   def create
     @shop = current_user.shops.new(shop_params)
+    @shop.img = "default.cafe.jpg"
     if @shop.save
       redirect_to root_path, notice: "登録しました"
     else

--- a/app/views/beans/show.html.erb
+++ b/app/views/beans/show.html.erb
@@ -2,7 +2,11 @@
 <div class="shop-show">
   <div class="row">
     <div class="col-xl-4 shop-picture">
-      <img src=<%= @bean.img.url %> class="img-fluid" alt="コーヒー豆のイメージ">
+      <% if @bean.img.present? %>
+        <img src=<%= @bean.img.url %> class="img-fluid" alt="コーヒー豆のイメージ">
+      <% else %>
+        <%= image_tag "default-beans.jpg", class: "img-fluid" %>
+      <% end %>
     </div>
     <div class="col-xl-8 shop-detail">
       <div class="row">

--- a/app/views/shops/show.html.erb
+++ b/app/views/shops/show.html.erb
@@ -2,7 +2,11 @@
 <div class="shop-show">
   <div class=row>
     <div class="col-xl-4 shop-picture">
-      <img src=<%= @shop.img.url %> class="img-fluid">
+      <% if @shop.img.present? %>
+        <img src=<%= @shop.img.url %> class="img-fluid">
+      <% else %>
+        <%= image_tag "default-cafe.jpg", class: "img-fluid" %>
+      <% end %>
     </div>
     <div class="col-xl-8 shop-detail">
       <div class="row">


### PR DESCRIPTION
## 修正内容

- 店舗詳細ページのデフォルト画像がユーザーのデフォルト画像となってしまっている不具合を解消
  - `img src`では`asset`内の画像が表示されないので`image_tag`を使用

- コーヒー豆詳細ページのデフォルト画像がユーザーのデフォルト画像となってしまっている不具合を解消
  -  `img src`では`asset`内の画像が表示されないので`image_tag`を使用