### PR TITLE
店舗一覧ページで評価が高い順で並べ替えを行った際の不具合を解消

### DIFF
--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -21,8 +21,12 @@ class Shop < ApplicationRecord
   }
 
   def update_rate_average
-    shop_comments_average = shop_comments.average(:rate)
-    update(rate_average: shop_comments_average)
+    if shop_comments.present?
+      shop_comments_average = shop_comments.average(:rate)
+      update(rate_average: shop_comments_average)
+    else
+      update(rate_average: 0.0)
+    end
   end
 
   mount_uploader :img, ImgUploader

--- a/app/views/shops/_shop.html.erb
+++ b/app/views/shops/_shop.html.erb
@@ -16,7 +16,7 @@
       <p><%= shop.prefecture %><%= shop.address %></p>
     </div>
     <div class="shop-rate">
-      <div class="average-review-rating" data-score=<%= shop.shop_comments.average(:rate) %>></div>
+      <div class="average-review-rating" data-score=<%= shop.rate_average %>></div>
       <%= render "/layouts/average" %>
     </div>
   </div>


### PR DESCRIPTION
## 不具合箇所
- 店舗一覧ページで、店舗のコメントが削除されて評価が0となったはずの店舗が評価の高い順で並び替えた際、一番上に表示されてしまっている。


## 要因
- 店舗のコメントが削除された際、評価が0になっていない

## 修正内容
- `shop.rb`の`update_rate_average`メソッドを修正
``` ruby
def update_rate_average
    if shop_comments.present?
      shop_comments_average = shop_comments.average(:rate)
      update(rate_average: shop_comments_average)
    else
      update(rate_average: 0.0)
    end
  end
```
上記のように条件分岐にし、コメントが存在しない場合`rate_average`カラムの値を0.0とした