### PR TITLE
全体の修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -78,7 +78,7 @@ a:hover {
     font-weight: 600;
     line-height: 0.5;
     position: relative;
-    display: inline-block;
+    display: block;
     padding: 0.5rem 1rem;
     cursor: pointer;
     -webkit-user-select: none;

--- a/app/assets/stylesheets/beans.scss
+++ b/app/assets/stylesheets/beans.scss
@@ -1,49 +1,48 @@
 // Place all the styles related to the beans controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
-
 .price {
-  margin: 0.5rem 0;
+    margin: 0.5rem 0;
 }
 
 .contents {
-  margin: 0;
-  padding: 1rem 1rem 0.5rem 1rem;
-  text-align: center;
-  background-color: #ffebcd;
-  border-radius: 0.5rem;
+    margin: 0;
+    padding: 1rem 1rem 0.5rem 1rem;
+    text-align: center;
+    background-color: #ffebcd;
+    border-radius: 0.5rem;
 }
 
 .bean-title {
-  margin-bottom: 0.5rem;
-  font-size: 1.6rem;
-  font-weight: 600;
-  height: 4rem;
-  text-align: center;
-  color: #555;
+    margin-bottom: 0.5rem;
+    font-size: 1.6rem;
+    font-weight: 600;
+    height: 4rem;
+    text-align: center;
+    color: #555;
 }
 
 .bean-tag {
-  float: left;
+    float: left;
 }
 
 .bean-content {
-  text-align: right;
+    text-align: right;
 }
 
 .underline {
-  padding-top: 0.5rem;
-  border-bottom: dashed 2px #d2b48c;
+    padding-top: 0.5rem;
+    border-bottom: dashed 2px #d2b48c;
 }
 
 @media only screen and (min-width: 780px) {
-  .bean-title {
-    font-size: 1.2rem;
-  }
+    .bean-title {
+        font-size: 1.2rem;
+    }
 }
 
 @media not all and (min-width: 768px) {
-  .contents {
-    font-size: 1.2rem;
-  }
+    .contents {
+        font-size: 1.2rem;
+    }
 }

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -2,77 +2,77 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
 .icon-image {
-  width: 200px;
-  height: 200px;
-  border-radius: 100px;
-  object-fit: cover;
+    width: 200px;
+    height: 200px;
+    border-radius: 100px;
+    object-fit: cover;
 }
 
 .profile-wrap {
-  margin: 40px 0px;
+    margin: 40px 0px;
 }
 
 .login {
-  max-width: 80%;
-  margin: 30px auto;
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+    max-width: 80%;
+    margin: 30px auto;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 }
 
 h1 {
-  text-align: center;
-  margin: 10px 0 30px;
+    text-align: center;
+    margin: 10px 0 30px;
 }
 
 .guest-login-button {
-  text-align: center;
-  background-color: #79c06e;
-  border-radius: 0.5rem;
+    text-align: center;
+    background-color: #79c06e;
+    border-radius: 0.5rem;
 }
 
 .login-button {
-  text-align: center;
-  background-color: #fa8072;
-  border-radius: 0.5rem;
+    text-align: center;
+    background-color: #fa8072;
+    border-radius: 0.5rem;
 }
 
 .delete-button {
-  text-align: center;
-  background-color: #fff;
-  margin-top: 2rem;
+    text-align: center;
+    background-color: #fff;
+    margin-top: 2rem;
 }
 
 .field {
-  margin: 10px 0 10px;
+    margin: 10px 0 10px;
 }
 
 .user-name {
-  font-size: 50px;
+    font-size: 50px;
 }
 
 .introduce {
-  background-color: #fff;
-  min-height: 10px;
+    background-color: #fff;
+    min-height: 10px;
 }
 
 .bg-lemon {
-  background-color: #fffff0;
+    background-color: #fffff0;
 }
 
 .bg-orange {
-  background-color: #ff8c00;
-  color: #fff;
+    background-color: #ff8c00;
+    color: #fff;
 }
 
 .introduction {
-  display: inline-block;
-  word-break: break-all;
-  padding: 1.5rem;
-  border-radius: 1rem;
-  letter-spacing: 0.1rem;
+    display: inline-block;
+    word-break: break-all;
+    padding: 1.5rem;
+    border-radius: 1rem;
+    letter-spacing: 0.1rem;
 }
 
 @media only screen and (min-width: 960px) {
-  .login {
-    max-width: 60%;
-  }
+    .login {
+        max-width: 60%;
+    }
 }

--- a/app/controllers/beans_comments_controller.rb
+++ b/app/controllers/beans_comments_controller.rb
@@ -18,7 +18,7 @@ class BeansCommentsController < ApplicationController
       @beans_comment.destroy!
       redirect_back(fallback_location: root_path, notice: "コメントを削除しました")
     else
-      render @beans
+      render "beans/show"
     end
   end
 

--- a/app/controllers/beans_comments_controller.rb
+++ b/app/controllers/beans_comments_controller.rb
@@ -16,9 +16,9 @@ class BeansCommentsController < ApplicationController
   def destroy
     if current_user.id == @beans_comment.user.id
       @beans_comment.destroy!
-      redirect_back(fallback_location: root_path)
+      redirect_back(fallback_location: root_path, notice: "コメントを削除しました")
     else
-      render "beans/show"
+      render @beans
     end
   end
 

--- a/app/controllers/beans_controller.rb
+++ b/app/controllers/beans_controller.rb
@@ -21,7 +21,7 @@ class BeansController < ApplicationController
   def create
     @bean = current_user.beans.new(bean_params)
     if @bean.save
-      redirect_to root_path, notice: "登録しました"
+      redirect_to beans_path, notice: "登録しました"
     else
       flash.now[:alert] = "登録に失敗しました"
       render :new
@@ -42,7 +42,7 @@ class BeansController < ApplicationController
 
   def destroy
     @bean.destroy!
-    redirect_to root_path
+    redirect_to beans_path, notice: "削除しました"
   end
 
   private

--- a/app/controllers/beans_controller.rb
+++ b/app/controllers/beans_controller.rb
@@ -37,7 +37,7 @@ class BeansController < ApplicationController
 
   def update
     @bean.update!(bean_params)
-    redirect_to @bean
+    redirect_to @bean, notice: "コーヒー豆の情報を更新しました"
   end
 
   def destroy

--- a/app/controllers/shop_comments_controller.rb
+++ b/app/controllers/shop_comments_controller.rb
@@ -14,7 +14,7 @@ class ShopCommentsController < ApplicationController
   def destroy
     if current_user.id == @shop_comment.user.id
       @shop_comment.destroy!
-      redirect_back(fallback_location: root_path)
+      redirect_back(fallback_location: root_path, notice: "コメントを削除しました")
     else
       render "shops/show"
     end

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -22,8 +22,9 @@ class ShopsController < ApplicationController
     @shop = current_user.shops.new(shop_params)
     @shop.img = "default.cafe.jpg"
     if @shop.save
-      redirect_to root_path, notice: "登録しました"
+
     else
+      redirect_to shops_path, notice: "登録しました"
       flash.now[:alert] = "登録に失敗しました"
       render :new
     end
@@ -49,7 +50,7 @@ class ShopsController < ApplicationController
 
   def destroy
     @shop.destroy!
-    redirect_to root_path
+    redirect_to shops_path, notice: "削除しました"
   end
 
   private

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -20,11 +20,9 @@ class ShopsController < ApplicationController
 
   def create
     @shop = current_user.shops.new(shop_params)
-    @shop.img = "default.cafe.jpg"
     if @shop.save
-
-    else
       redirect_to shops_path, notice: "登録しました"
+    else
       flash.now[:alert] = "登録に失敗しました"
       render :new
     end

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -45,7 +45,7 @@ class ShopsController < ApplicationController
 
   def update
     @shop.update!(shop_params)
-    redirect_to @shop
+    redirect_to @shop, notice: "店舗情報を更新しました"
   end
 
   def destroy

--- a/app/views/beans/_bean.html.erb
+++ b/app/views/beans/_bean.html.erb
@@ -2,7 +2,7 @@
   <a href="/beans/<%= bean.id %>" class="cards-body">
     <div class="cards-header">
       <% if bean.img? %>
-        <img src=<%= bean.image.url %> class="cards-image">
+        <img src=<%= bean.img.url %> class="cards-image">
       <% else %>
         <img src="assets/default-beans.jpg" class="cards-image">
       <% end %>

--- a/app/views/beans/_bean.html.erb
+++ b/app/views/beans/_bean.html.erb
@@ -11,7 +11,7 @@
       <P><%= bean.name %></P>
     </div>
   </a>
-  <div class="contents">
+  <div class="contents steel-gray">
     <div class="underline">
       <p class="bean-tag">販売店</p>
       <p class="bean-content"><a href="/shops/<%= bean.shop_id %>"><%= bean.shop.name %></a></p>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -37,7 +37,7 @@
       <div class="search-button">
         <%= f.submit "変更する", class: "btn btn-block form-submit-btn" %>
       </div>
-      <div class="login-button">
+      <div class="login-button mt-4">
         <%= link_to  "マイページへ", user_path(current_user), class: "btn btn-block" %>
       </div>
       <div class="delete-button">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -5,7 +5,11 @@
     </div>
     <div class="col-md-6 text-center">
       <h1 class="title"><%= @user.name %></h1>
-      <h6 class="introduction steel-gray bg-lemon"><%= @user.self_introduction %></h6>
+      <% if @user.self_introduction.present? %>
+        <h6 class="introduction steel-gray bg-lemon"><%= @user.self_introduction %></h6>
+      <% else %>
+        <h6 class="introduction steel-gray bg-lemon"><%= @user.name %>です</h6>
+      <% end %>
     </div>
   </div>
   <div class="row">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -33,6 +33,12 @@
                   </tr>
                 </tbody>
               </table>
+              <p class="link-box">
+                <% if current_user && current_user.id == shop.user_id %>
+                  <%= link_to "編集", edit_shop_path(shop) %>
+                  <%= link_to "削除", shop_path(shop), method: :delete, data: { confirm: "削除しますか？" } %>
+                <% end %>
+              </p>
             </div>
           </div>
         <% end %>
@@ -58,12 +64,17 @@
                   <td><%= bean.created_at.strftime('%Y/%m/%d') %></td>
                 </tr>
               </table>
+              <p class="link-box">
+                <% if current_user && current_user.id == bean.user_id %>
+                  <%= link_to "編集", edit_bean_path(bean) %>
+                  <%= link_to "削除", bean_path(bean), method: :delete, data: { confirm: "削除しますか？" } %>
+                <% end %>
+              </div>
             </div>
-          </div>
+          <% end %>
+        <% else %>
+          <h3 class="text-center steel-gray">まだ登録がありません</h3>
         <% end %>
-      <% else %>
-        <h3 class="text-center steel-gray">まだ登録がありません</h3>
-      <% end %>
+      </div>
     </div>
   </div>
-</div>


### PR DESCRIPTION
## 修正箇所

- 画面遷移先の変更
  - 店舗を登録・削除した際の画面遷移先を`shops#index`に変更
  - コーヒー豆を登録・削除した際の画面遷移先を`beans#index`に変更

- フラッシュメッセージの追加
  - 店舗の情報を更新した際のフラッシュメッセージを追加
  - コーヒー豆のの情報を更新した際のフラッシュメッセージを追加
  - 店舗詳細ページでコメントを削除した際のフラッシュメッセージを追加
  - コーヒー豆詳細ページでコメントを削除した際のフラッシュメッセージを追加

- ユーザー詳細ページの編集
  - userの`self_introduction`カラムが空の場合デフォルトの自己紹介文が表示されるよう変更
  - `current_user.id`が店舗・豆の投稿者のidと一致した場合にユーザー詳細ページに編集・削除のリンクを追加