### PR TITLE
フッターの作成・不具合の解消

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,6 +26,16 @@ body {
     font-family: 'Helvetica Neue', Arial, 'Hiragino Kaku Gothic ProN', 'Hiragino Sans', Meiryo, sans-serif;
 }
 
+footer {
+    width: 100%;
+    height: 50px;
+    padding-top: 0.8rem;
+    margin-top: 3rem;
+    background-color: #ff7f50;
+    color: white;
+    text-align: center;
+}
+
 .table {
     border-radius: 0.5rem;
     color: #736d71;

--- a/app/views/beans/_bean_form.html.erb
+++ b/app/views/beans/_bean_form.html.erb
@@ -22,8 +22,8 @@
       <%= f.text_field :farm, autofocus: true, class: "form-control" %>
     </div>
     <div class="form-group">
-      <%= f.label :valiety, "品種" %>
-      <%= f.text_field :valiety, autofocus: true, class: "form-control" %>
+      <%= f.label :variety, "品種" %>
+      <%= f.text_field :variety, autofocus: true, class: "form-control" %>
     </div>
     <div class="form-group">
       <%= f.label :screen_size, "大きさ" %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,6 +1,10 @@
 <nav class="nav navbar-expand-md navbar-dark fixed-top" id="mainNav">
   <div class="navbar-brand">
-    <h1 class="text-4xl font-semibold md:text-xl"><%= link_to "Cofee First", root_path, class: "btn btn-lg"  %></h1>
+    <% if user_signed_in? %>
+      <h1 class="text-4xl font-semibold md:text-xl"><%= link_to "Cofee First", beans_path, class: "btn btn-lg"  %></h1>
+    <% else %>
+      <h1 class="text-4xl font-semibold md:text-xl"><%= link_to "Cofee First", root_path, class: "btn btn-lg"  %></h1>
+    <% end %>
   </div>
   <button class="navbar-toggler hamburger-menu" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -11,8 +11,8 @@
   </button>
   <div class="collapse navbar-collapse" id="navbarNav">
     <ul class="navbar-nav">
-      <li class="nav-item dropdown active">
-        <a class="nav-link dropdown-toggle float-left" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <li class="nav-item dropdown active mr-3">
+        <a class="nav-link float-left" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           検索
         </a>
         <div class="dropdown-menu" aria-labelladby="navbarDropdownMenuLink">
@@ -20,8 +20,8 @@
           <%= link_to "豆を検索", beans_path, class: "dropdown-item" %>
         </div>
       </li>
-      <li class="nav-item dropdown active">
-        <a class="nav-link dropdown-toggle float-left" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <li class="nav-item dropdown active mr-3">
+        <a class="nav-link float-left" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           登録
         </a>
         <div class="dropdown-menu" aria-labelladby="navbarDropdownMenuLink">
@@ -30,8 +30,8 @@
         </div>
       </li>
       <% if user_signed_in? %>
-        <li class="nav-item dropdown active">
-          <a class="nav-link dropdown-toggle float-left" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <li class="nav-item dropdown active mr-3">
+          <a class="nav-link float-left" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <%= current_user.name %>
           </a>
           <div class="dropdown-menu" aria-labelladby="navbarDropdownMenuLink">
@@ -43,8 +43,8 @@
         </li>
         <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？"}, class: "nav-item nav-link active text-left" %>
       <% else %>
-        <%= link_to "新規登録", new_user_registration_path, class: "nav-item nav-link active text-left" %>
-        <%= link_to "ログイン", new_user_session_path, class: "nav-item nav-link active text-left" %>
+        <%= link_to "新規登録", new_user_registration_path, class: "nav-item nav-link active text-left mr-3" %>
+        <%= link_to "ログイン", new_user_session_path, class: "nav-item nav-link active text-left mr-3" %>
         <%= link_to "ゲストログイン（閲覧用）", users_guest_sign_in_path, method: :post, class: "nav-item nav-link active text-left" %>
       <% end %>
     </ul>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,7 @@
       </div>
     </main>
     <footer>
+      <p>© Kohei Hashimoto All rights reserved</p>
     </footer>
   </body>
 </html>


### PR DESCRIPTION
## 実装内容

- フッターの作成

## 修正箇所

- ログイン済みの場合`navbar-brand`のリンク先を`beans#index`に変更
- コーヒー豆の品種が登録されていた場合でもコーヒー豆詳細ページに表示されない不具合の解消
- ヘッダーの各`nav-item`に`mr-3`を適用